### PR TITLE
make storage independent from utils and log

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,7 +17,10 @@ var store *storage.Storage
 var dbus *distributor.DBus
 
 func main() {
-	store = storage.InitStorage("np2p")
+	var err error
+	if store, err = storage.InitStorage(utils.StoragePath("np2p.db")); err != nil {
+		log.Fatalln("failed to connect database")
+	}
 	config.Init("np2p")
 
 	dbus = distributor.NewDBus("org.unifiedpush.Distributor.NP2P")

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1,23 +1,20 @@
 package storage
 
 import (
-	"log"
-
 	"github.com/google/uuid"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
-	"unifiedpush.org/go/np2p_dbus/utils"
 )
 
-func InitStorage(name string) *Storage {
-	db, err := gorm.Open(sqlite.Open(utils.StoragePath(name+".db")), &gorm.Config{})
+func InitStorage(filepath string) (*Storage, error) {
+	db, err := gorm.Open(sqlite.Open(filepath), &gorm.Config{})
 	if err != nil {
-		log.Fatalln("failed to connect database")
+		return nil, err
 	}
 
 	// Migrate the schema
 	db.AutoMigrate(&Connection{})
-	return &Storage{db: db}
+	return &Storage{db: db}, nil
 }
 
 type Storage struct {


### PR DESCRIPTION
utils contains naming of np2p like:
https://github.com/NoProvider2Push/dbus/blob/6fefd6f17883cb4a9f6c935baac7129389ac55f0/utils/utils.go#L19

for reuse in other application it would be nice, to have an independent storage by path 