### PR TITLE
storage: Allow own PublicToken

### DIFF
--- a/storage/storage.go
+++ b/storage/storage.go
@@ -23,7 +23,6 @@ type Storage struct {
 
 func (s Storage) NewConnection(appID, token string, endpoint string) *Connection {
 	c := Connection{
-		db:          s.db,
 		AppID:       appID,
 		AppToken:    token,
 		PublicToken: uuid.New().String(),
@@ -66,8 +65,6 @@ func (s Storage) getFirst(c Connection) *Connection {
 }
 
 type Connection struct {
-	db *gorm.DB
-
 	AppID       string
 	AppToken    string `gorm:"primaryKey"`
 	PublicToken string `gorm:"unique"`

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -22,10 +22,13 @@ type Storage struct {
 }
 
 func (s Storage) NewConnection(appID, token string, endpoint string) *Connection {
+	return s.NewConnectionWithToken(appID, token, uuid.New().String(), endpoint)
+}
+func (s Storage) NewConnectionWithToken(appID, token string, publicToken, endpoint string) *Connection {
 	c := Connection{
 		AppID:       appID,
 		AppToken:    token,
-		PublicToken: uuid.New().String(),
+		PublicToken: publicToken,
 		Endpoint:    endpoint,
 	}
 	result := s.db.Create(&c)


### PR DESCRIPTION
i do not know the Endpoint before PublicToken, there are two options to solve it:
- make it possible to update Endpoint
- make it possible to define somewhere else the PublicToken and store everything together at the same time


this make the last option possible 