### PR TITLE
storage: NewConnectionWithToken save PublicToken

### DIFF
--- a/storage/storage.go
+++ b/storage/storage.go
@@ -30,6 +30,7 @@ func (s Storage) NewConnection(appID, token string, endpoint string) *Connection
 func (s Storage) NewConnectionWithToken(appID, token string, publicToken, endpoint string) *Connection {
 	existing := s.getFirst(Connection{AppID: appID, AppToken: token})
 	if existing != nil {
+		existing.PublicToken = publicToken
 		existing.Endpoint = endpoint
 		if err := s.db.Save(existing).Error; err != nil {
 			return nil

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -6,10 +6,13 @@ import (
 	"github.com/google/uuid"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
 )
 
 func InitStorage(filepath string) (*Storage, error) {
-	db, err := gorm.Open(sqlite.Open(filepath), &gorm.Config{})
+	db, err := gorm.Open(sqlite.Open(filepath), &gorm.Config{
+		Logger: logger.Default.LogMode(0),
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,6 +18,7 @@ func TestInit(t *testing.T) {
 
 	db, err = InitStorage(STORAGE_PATH)
 	assert.NoError(err)
+	defer os.Remove(STORAGE_PATH)
 	assert.NotNil(db)
 }
 
@@ -25,6 +27,7 @@ func TestNewConnectionWithGeneratedToken(t *testing.T) {
 
 	db, err := InitStorage(STORAGE_PATH)
 	assert.NoError(err)
+	defer os.Remove(STORAGE_PATH)
 
 	appID := "app-1"
 	appToken := "apptoken-2"
@@ -49,6 +52,7 @@ func TestNewConnectionCollision(t *testing.T) {
 
 	db, err := InitStorage(STORAGE_PATH)
 	assert.NoError(err)
+	defer os.Remove(STORAGE_PATH)
 
 	appID := "app-1"
 	publicToken := "public-token-2"
@@ -69,6 +73,7 @@ func TestNewConnectionUpdateEndpoint(t *testing.T) {
 
 	db, err := InitStorage(STORAGE_PATH)
 	assert.NoError(err)
+	defer os.Remove(STORAGE_PATH)
 
 	appID := "app-1"
 	appToken := "apptoken-2"
@@ -97,6 +102,7 @@ func TestGetConnectionbyPublic(t *testing.T) {
 
 	db, err := InitStorage(STORAGE_PATH)
 	assert.NoError(err)
+	defer os.Remove(STORAGE_PATH)
 
 	publicToken := "public-token-2"
 
@@ -115,6 +121,7 @@ func TestDeleteConnection(t *testing.T) {
 
 	db, err := InitStorage(STORAGE_PATH)
 	assert.NoError(err)
+	defer os.Remove(STORAGE_PATH)
 
 	appToken := "apptoken-2"
 


### PR DESCRIPTION
NewConnectionWithToken should update both PublicToken and Endpoint (not only one)